### PR TITLE
Reflect real fog dependencies in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'fog', '~>1.23.0'
+gem 'fog', '~> 1.24'
 gem 'berkshelf', '~>3.1.5'
 gem 'chefspec', '~>4.0.1'
 gem 'rspec_junit_formatter', '~>0.1.6'


### PR DESCRIPTION
Fog <= 1.23.0 does not support the wildcard protocol notation already being used in this cookbook:

```
           ================================================================================
           Error executing action `remove` on resource 'aws_security_group_rule[test rule 4]'
           ================================================================================

           Fog::Compute::AWS::Error
           ------------------------
           Malformed => Unsupported IP protocol \"-1\"  - supported: [tcp, udp, icmp]

           Cookbook Trace:
           ---------------
           /tmp/kitchen/cache/cookbooks/aws_security/providers/group_rule.rb:31:in `block (2 levels) in class_from_file'
           /tmp/kitchen/cache/cookbooks/aws_security/providers/group_rule.rb:27:in `block in class_from_file'

           Resource Declaration:
           ---------------------
           # In /tmp/kitchen/cache/cookbooks/fake/recipes/test2.rb

            75: aws_security_group_rule 'test rule 4' do
            76:   cidr_ip "192.168.1.3/32"
            77:   groupname "test"
            78:   region 'us-west-2'
            79:   ip_protocol '-1'
            80:   action :remove
            81: end
            82: 
```
