### PR TITLE
Relax rspec_junit_formatter version constrant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'fog', '~>1.23.0'
 gem 'berkshelf', '~>3.1.5'
 gem 'chefspec', '~>4.0.1'
-gem 'rspec_junit_formatter', '~>0.1.6'
+gem 'rspec_junit_formatter', '~> 0.1'
 
 group :integration do
   gem 'test-kitchen', '~>1.2.1'


### PR DESCRIPTION
As currently implemented, I get this error when I try to do `bundle update`:

```
$ bundle update
Fetching gem metadata from https://rubygems.org/.......
Fetching additional metadata from https://rubygems.org/..
Resolving dependencies...
Bundler could not find compatible versions for gem "rspec":
  In Gemfile:
    rspec_junit_formatter (~> 0.1.6) ruby depends on
      rspec (~> 2.0) ruby

    chefspec (~> 4.0.1) ruby depends on
      rspec (3.0.0)
```
