### PR TITLE
Do not use node attributes to store secure objects

### DIFF
--- a/providers/group.rb
+++ b/providers/group.rb
@@ -30,17 +30,17 @@ def load_current_resource
   @current_resource =
     Chef::Resource::AwsSecurityGroup.new(@new_resource.groupname)
 
-  %w(groupname
+  %w(aws_access_key_id
+     aws_secret_access_key
+     groupname
      description
      vpcid
      region).each do |attrib|
     @current_resource.send(attrib, @new_resource.send(attrib))
   end
 
-  @current_resource.aws_access_key_id(@new_resource.aws_access_key_id ||
-    node['aws_security']['aws_access_key_id'])
-  @current_resource.aws_secret_access_key(@new_resource.aws_secret_access_key ||
-    node['aws_security']['aws_secret_access_key'])
+  @current_resource.mocking(@new_resource.mocking ||
+                            node['aws_security']['mocking'])
 
   @current_resource.exists = true if security_group
 end

--- a/providers/group_rule.rb
+++ b/providers/group_rule.rb
@@ -37,16 +37,12 @@ def load_current_resource
   @current_resource =
     Chef::Resource::AwsSecurityGroupRule.new(@new_resource.name)
 
-  @current_resource.aws_access_key_id(
-    @new_resource.aws_access_key_id ||
-    node['aws_security']['aws_access_key_id']
-  )
-  @current_resource.aws_secret_access_key(
-    @new_resource.aws_access_key_id ||
-    node['aws_security']['aws_secret_access_key']
-  )
+  @current_resource.mocking(@new_resource.mocking ||
+                            node['aws_security']['mocking'])
 
-  %w(groupname
+  %w(aws_access_key_id
+     aws_secret_access_key
+     groupname
      name
      cidr_ip
      group

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,13 +22,3 @@
 
 include_recipe "fog_gem::chefgem"
 
-
-if node['aws_security']['encrypted_data_bag']
-  databag_item = Chef::EncryptedDataBagItem.load(
-    node['aws_security']['encrypted_data_bag'],
-  	'aws_keys'
-  )
-  node.set['aws_security']['aws_access_key_id'] = databag_item['aws_access_key_id']
-  node.set['aws_security']['aws_secret_access_key'] = databag_item['aws_secret_access_key']
-end
-

--- a/test/fixtures/cookbooks/fake/recipes/add_test.rb
+++ b/test/fixtures/cookbooks/fake/recipes/add_test.rb
@@ -42,9 +42,16 @@ template '/root/.aws/config' do
   )
 end
 
+credentials = Chef::EncryptedDataBagItem.load(
+  node['aws_security']['encrypted_data_bag'],
+  'aws_keys'
+)
+
 aws_security_group 'test' do
   description 'test security group'
   region 'us-west-2'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
 end
 
 aws_security_group_rule 'test rule 1' do
@@ -54,6 +61,8 @@ aws_security_group_rule 'test rule 1' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
 end
 
 aws_security_group_rule 'test rule 2' do
@@ -62,6 +71,8 @@ aws_security_group_rule 'test rule 2' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'udp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
 end
 
 aws_security_group_rule 'test rule 3' do
@@ -70,6 +81,8 @@ aws_security_group_rule 'test rule 3' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
 end
 
 aws_security_group_rule 'test rule 3 (duplicate)' do
@@ -78,6 +91,8 @@ aws_security_group_rule 'test rule 3 (duplicate)' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
 end
 
 aws_security_group_rule 'test rule 4' do
@@ -86,6 +101,8 @@ aws_security_group_rule 'test rule 4' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
 end
 
 aws_security_group_rule 'test rule 5' do
@@ -93,4 +110,6 @@ aws_security_group_rule 'test rule 5' do
   groupname 'test'
   region 'us-west-2'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
 end

--- a/test/fixtures/cookbooks/fake/recipes/remove_test.rb
+++ b/test/fixtures/cookbooks/fake/recipes/remove_test.rb
@@ -42,6 +42,11 @@ template '/root/.aws/config' do
   )
 end
 
+credentials = Chef::EncryptedDataBagItem.load(
+  node['aws_security']['encrypted_data_bag'],
+  'aws_keys'
+)
+
 aws_security_group_rule 'test rule 1' do
   description 'test rule 1'
   cidr_ip '192.168.1.1/32'
@@ -49,6 +54,8 @@ aws_security_group_rule 'test rule 1' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
   action :remove
 end
 
@@ -58,6 +65,8 @@ aws_security_group_rule 'test rule 2' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'udp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
   action :remove
 end
 
@@ -67,6 +76,8 @@ aws_security_group_rule 'test rule 3' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
   action :remove
 end
 
@@ -76,6 +87,8 @@ aws_security_group_rule 'test rule 3 (duplicate)' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
   action :remove
 end
 
@@ -85,6 +98,8 @@ aws_security_group_rule 'test rule 4' do
   region 'us-west-2'
   port_range '80..80'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
   action :remove
 end
 
@@ -93,11 +108,15 @@ aws_security_group_rule 'test rule 5' do
   groupname 'test'
   region 'us-west-2'
   ip_protocol 'tcp'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
   action :remove
 end
 
 aws_security_group 'test' do
   description 'test security group'
   region 'us-west-2'
+  aws_access_key_id credentials['aws_access_key_id']
+  aws_secret_access_key credentials['aws_secret_access_key']
   action :remove
 end


### PR DESCRIPTION
It defeats the purpose of using encrypted data bags because the data gets stored back on the Chef server in plain text.
