### PR TITLE
identify security groups by VPC (or lack thereof)

### DIFF
--- a/providers/group.rb
+++ b/providers/group.rb
@@ -49,7 +49,7 @@ end
 def security_group
   @sg ||= ec2.security_groups.all(
             'group-name' => [@current_resource.groupname]
-          ).first
+          ).find { |g| g.vpc_id == @current_resource.vpcid }
 end
 
 def create_security_group


### PR DESCRIPTION
It's valid to have like-named SGs in different VPCs.  It's necessary
to identify them by their VPC ID.  This works also for SGs that are
not in a VPC.